### PR TITLE
Change package-names from tpm to tpm2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,10 +7,10 @@ rec {
   youtube-rss = pkgs.callPackage ./pkgs/youtuberss.nix {};
 
   # TODO update and eventually upstream into nixpkgs
-  tpm2-tools = pkgs.callPackage ./pkgs/tpm2-tools.nix {
-    tpm-tss = tpm2-tss;
+  tpm2-tools = pkgs.callPackage ./pkgs/tpm2/tpm2-tools.nix {
+    tpm2-tss = tpm2-tss;
   };
-  tpm2-tss = pkgs.callPackage ./pkgs/tpm2-tss.nix {};
+  tpm2-tss = pkgs.callPackage ./pkgs/tpm2/tpm2-tss.nix {};
 
   libdatrie = pkgs.callPackage ./pkgs/libdatrie.nix {};
   libthai = pkgs.callPackage ./pkgs/libthai.nix {

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ rec {
 
   # TODO update and eventually upstream into nixpkgs
   tpm2-tools = pkgs.callPackage ./pkgs/tpm2/tpm2-tools.nix {
-    tpm2-tss = tpm2-tss;
+    inherit tpm2-tss;
   };
   tpm2-tss = pkgs.callPackage ./pkgs/tpm2/tpm2-tss.nix {};
 

--- a/pkgs/tpm2/tpm2-tools.nix
+++ b/pkgs/tpm2/tpm2-tools.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv, fetchurl, libtool, pkgconfig, libgcrypt, tpm-tss, openssl, curl, pandoc,
+{ lib, stdenv, fetchurl, libtool, pkgconfig, libgcrypt, tpm2-tss, openssl, curl, pandoc,
   python36, file
 }:
 stdenv.mkDerivation rec {
   version = "3.1.2";
-  name = "tpm-tools-${version}";
+  name = "tpm2-tools-${version}";
 
   src = fetchurl {
     url = "https://github.com/tpm2-software/tpm2-tools/releases/download/${version}/tpm2-tools-${version}.tar.gz";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libtool pkgconfig
-    tpm-tss
+    tpm2-tss
     openssl libgcrypt
     curl.dev
 

--- a/pkgs/tpm2/tpm2-tss.nix
+++ b/pkgs/tpm2/tpm2-tss.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, pkgconfig, libgcrypt, doxygen, file, perl }:
 
 stdenv.mkDerivation rec {
-  name = "tpm-tss-${version}";
+  name = "tpm2-tss-${version}";
   version = "2.0.1";
 
   src = fetchurl {


### PR DESCRIPTION
The packages should be called `tpm2` to avoid confusion. Additionally, I've put them into a sub folder called `tpm2`.

Both `tpm2-tss` and `tpm2-tools` build successfully on my system.