### PR TITLE
Flake setup for hponcfg

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1660358575,
+        "narHash": "sha256-EMIn5yM/fDorK5C+DLaxz4/ysP0lpj9xEwbN6gKIkWM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "71d9ee04f44051acbca335b6c5f583902e329987",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "changeme";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+      lib = pkgs.lib;
+    in
+    rec {
+      packages = flake-utils.lib.flattenTree {
+        hponcfg = pkgs.callPackage ./pkgs/hponcfg.nix { };
+        default = pkgs.stdenv.mkDerivation {
+          name = "changeme";
+
+          buildInputs = [
+            packages.hponcfg
+          ];
+
+          src = ./.;
+
+          doCheck = false;
+
+          installPhase = ''
+            install -dm755 $out
+          '';
+        };
+      };
+
+      apps = {
+        hponcfg = flake-utils.lib.mkApp { drv = packages.hponcfg; };
+      };
+
+      defaultApp = flake-utils.lib.mkApp {
+        drv = packages.default;
+      };
+
+      devShell = pkgs.mkShell {
+        buildInputs = [
+          packages.hponcfg
+        ];
+      };
+
+      checks = {
+        nixpkgs-fmt = pkgs.runCommand "check-nix-format" { } ''
+          ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt --check ${./.}
+          install -dm755 $out
+        '';
+      };
+    });
+}

--- a/pkgs/hponcfg.nix
+++ b/pkgs/hponcfg.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    mainProgram = "hponcfg";
     description = "HPE RILOE II/iLO online configuration utility";
     maintainers = with lib.maintainers; [ johnazoidberg ];
     license = lib.licenses.unfree;


### PR DESCRIPTION
Makes using hponcfg a bit easier and lets you use nix run to run it on systems that might not yet be fully formed.

Aka it makes this possible:

```
$ NIXPKGS_ALLOW_UNFREE=1 nix run --impure github:mitchty/johnazoidberg-nur-packages/flake#hponcfg -- -h                                                                  
HPE Lights-Out Online Configuration utility                                              
Version 5.6.0 Date 11/30/2020 (c) 2005,2020 Hewlett Packard Enterprise Development LP    
QYou are not a root/superuser. Only root/superuser can access the utility.               
zsh: exit 7     NIXPKGS_ALLOW_UNFREE=1 nix run --impure  -- -h 
```

The flake-utils usage might be a bit pointless in this instance. I left any other packages as-is as I didn't need them.

Otherwise thanks for a derivation for hponcfg! I bought a second hand server and this let me reset the ilo password without installing centos which was nice.

